### PR TITLE
:bricks: Adds publishing of pre-release packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - '*'
+      - '!main'
 
 env:
   DOTNET_VERSION: '5.0.x'

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -1,0 +1,29 @@
+﻿name: Publish Pre-Release
+on:
+  push:
+    branches:
+      - 'main'
+
+env:
+  DOTNET_VERSION: '5.0.x'
+
+jobs:
+  build:
+    name: Publish Pre-release Package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup .Net
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{env.DOTNET_VERSION}}
+      - name: Restore Dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+      - name: Test
+        run: dotnet test --no-restore --verbosity normal
+      - name: Pack for Publishing
+        run: dotnet pack --configuration Release
+      - name: Publish Pre-release Package
+        run: dotnet nuget push src/bin/Release/*-rc.nupkg --api-key ${{secrets.CI_PUBLISH_PKG_PAT}} --source https://nuget.pkg.github.com/cmiles74/index.json

--- a/src/Nervestaple.EntityFrameworkCore.csproj
+++ b/src/Nervestaple.EntityFrameworkCore.csproj
@@ -8,6 +8,7 @@
     <Company>Nervestaple Development</Company>
     <Product>Nervestaple.EntityFrameworkCore</Product>
     <Description>Wraps EntityFrameworkCore to help create database backed respositories</Description>
+    <RepositoryUrl>https://github.com/cmiles74/EntityFrameworkCore.git</RepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This adds a GitHub Action that will publish a pre-release NuGet package whenever we push to the `main` branch.